### PR TITLE
Add Notebook 4.1 Run Transformer Models

### DIFF
--- a/ch_4_Run_Models/4_1_Run_Transformer_Models.ipynb
+++ b/ch_4_Run_Models/4_1_Run_Transformer_Models.ipynb
@@ -1,551 +1,550 @@
 {
-  "cells": [
-   {
-    "attachments": {},
-    "cell_type": "markdown",
-    "metadata": {},
-    "source": [
-     "# Notebook 4.1: Run Transformer Models\n",
-     "\n",
-     "BigDL-LLM supports the optimization of any Hugging Face *transformers* model, allowing for efficient inference with significantly reduced latency. With the help of BigDL-LLM, PyTorch models (in FP16/BF16/FP32) from Hugging Face can be loaded with implicit quantization, so that heavy operations in Transformer can be speeded up through low precision (such as INT4/INT5/INT8, etc.).\n",
-     "\n",
-     "In this tutorial, we will dive into the main usage of BigDL-LLM Transformers-style API for low-precision optimizations.\n",
-     "\n",
-     "## 4.1.1 Install BigDL-LLM\n",
-     "\n",
-     "Follow instructions in [Chapter 2](../ch_2_Environment_Setup/) to setup your environment if you haven't done so. Then install `bigdl-llm`:"
-    ]
-   },
-   {
-    "cell_type": "code",
-    "execution_count": null,
-    "metadata": {},
-    "outputs": [],
-    "source": [
-     "!pip install BigDL-LLM[all]"
-    ]
-   },
-   {
-    "attachments": {},
-    "cell_type": "markdown",
-    "metadata": {},
-    "source": [
-     "## 4.1.2 Load Model in INT4 and Conduct Inference\n",
-     "\n",
-     "One common use case for BigDL-LLM is to load a Hugging Face *transformers* model in INT4 precision and conduct inference with optimizations. Compared to the Hugging Face *transformers* API, only minor code changes are required.\n",
-     "\n",
-     "For illustration purposes, let's take model [meta-llama/Llama-2-7b-chat-hf](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf) as an example.\n",
-     "\n",
-     "### 4.1.2.1 Download Llama 2 (7B)\n",
-     "\n",
-     "To download the [meta-llama/Llama-2-7b-chat-hf](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf) model from Hugging Face, you will need to obtain access granted by Meta. Please follow the instructions provided [here](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/tree/main) to request access to the model.\n",
-     "\n",
-     "After receiving the access, download the model with your Hugging Face token:"
-    ]
-   },
-   {
-    "cell_type": "code",
-    "execution_count": null,
-    "metadata": {},
-    "outputs": [],
-    "source": [
-     "from huggingface_hub import snapshot_download\n",
-     "\n",
-     "model_path = snapshot_download(repo_id='/meta-llama/Llama-2-7b-chat-hf',\n",
-     "                               token='hf_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX') # change it to your own Hugging Face access token"
-    ]
-   },
-   {
-    "attachments": {},
-    "cell_type": "markdown",
-    "metadata": {},
-    "source": [
-     "> **Note**\n",
-     ">\n",
-     "> The model will by default be downloaded to `HF_HOME='~/.cache/huggingface'`.\n",
-     "\n",
-     "\n",
-     "### 4.1.1.2 Load Model in INT4\n",
-     "\n",
-     "To load the model with BigDL-LLM INT4 optimizations, you could simply import `bigdl.llm.transformers.AutoModelForCausalLM` instead of `transformers.AutoModelForCausalLM`, and specify `load_in_4bit=True` in the `from_pretrained` function:"
-    ]
-   },
-   {
-    "cell_type": "code",
-    "execution_count": null,
-    "metadata": {},
-    "outputs": [],
-    "source": [
-     "from bigdl.llm.transformers import AutoModelForCausalLM\n",
-     "\n",
-     "# model_in_4bit = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path=\"meta-llama/Llama-2-7b-chat-hf\",\n",
-     "#                                                      load_in_4bit=True)\n",
-     "model_in_4bit = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path=\"/disk5/yuwen/models/Llama-2-7b-chat-hf\",\n",
-     "                                                     load_in_4bit=True)"
-    ]
-   },
-   {
-    "attachments": {},
-    "cell_type": "markdown",
-    "metadata": {},
-    "source": [
-     "> **Note**\n",
-     ">\n",
-     "> BigDL-LLM has supported `AutoModel`, `AutoModelForCausalLM`, `AutoModelForSpeechSeq2Seq` and `AutoModelForSeq2SeqLM`.\n",
-     "\n",
-     "### 4.1.2.3 Load Tokenizer and Conduct Inference\n",
-     "\n",
-     "You could then load the corresponding tokenizer of Llama 2 (7B) and conduct inference with BigDL-LLM INT4 optimizations, in the exactly same way with using Hugging Face *transformers* API. A human-bot conversation is constructed here for the model to complete:"
-    ]
-   },
-   {
-    "cell_type": "code",
-    "execution_count": 3,
-    "metadata": {},
-    "outputs": [
-     {
-      "name": "stdout",
-      "output_type": "stream",
-      "text": [
-       "Inference time: xxxx s\n",
-       "-------------------- Output --------------------\n",
-       "### HUMAN:\n",
-       "\n",
-       "What is AI?\n",
-       "\n",
-       "### RESPONSE:\n",
-       "\n",
-       "AI is a branch of computer science that focuses on creating intelligent machines that can perform tasks that typically require human intelligence, such as understanding natural language,\n"
-      ]
-     }
-    ],
-    "source": [
-     "# Load tokenizer of Llama 2 (7B)\n",
-     "from transformers import LlamaTokenizer\n",
-     "# tokenizer = LlamaTokenizer.from_pretrained(pretrained_model_name_or_path=\"meta-llama/Llama-2-7b-chat-hf\")\n",
-     "tokenizer = LlamaTokenizer.from_pretrained(pretrained_model_name_or_path=\"/disk5/yuwen/models/Llama-2-7b-chat-hf\")\n",
-     "\n",
-     "# Generate predicted tokens\n",
-     "import torch\n",
-     "import time\n",
-     "\n",
-     "prompt = \"\"\"### HUMAN:\n",
-     "\n",
-     "What is AI?\n",
-     "\n",
-     "### RESPONSE:\n",
-     "\"\"\"\n",
-     "\n",
-     "with torch.inference_mode():\n",
-     "    input_ids = tokenizer.encode(prompt, return_tensors=\"pt\")\n",
-     "    st = time.time()\n",
-     "    output = model_in_4bit.generate(input_ids,\n",
-     "                                    max_new_tokens=32)\n",
-     "    end = time.time()\n",
-     "    output_str = tokenizer.decode(output[0], skip_special_tokens=True)\n",
-     "    print(f'Inference time: {end-st} s')\n",
-     "    print('-'*20, 'Output', '-'*20)\n",
-     "    print(output_str)"
-    ]
-   },
-   {
-    "attachments": {},
-    "cell_type": "markdown",
-    "metadata": {},
-    "source": [
-     "### 4.1.2.4 Conduct Streaming Multi-Turn Chat\n",
-     "\n",
-     "One common application of large language models is as chatbots. There is no magic involved in chatbot interactions. LLMs simply predict and generated texts based on formatted, incomplete conversations, such as the example prompt we previously showcased:\n",
-     "\n",
-     "```\n",
-     "### HUMAN:\n",
-     "\n",
-     "What is AI?\n",
-     "\n",
-     "### RESPONSE:\n",
-     "```\n",
-     "\n",
-     "In multi-turn chatting, the generated texts by LLMs are added into the existing conversation texts, as follows:\n",
-     "\n",
-     "```\n",
-     "### HUMAN:\n",
-     "\n",
-     "What is AI?\n",
-     "\n",
-     "### RESPONSE:\n",
-     "\n",
-     "AI is a term used to describe the development of computer systems that can perform tasks that typically require human intelligence, such as understanding natural language, recognizing images.\n",
-     "\n",
-     "### HUMAN:\n",
-     "\n",
-     "Is it dangerous\n",
-     "\n",
-     "### RESPONSE:\n",
-     "```\n",
-     "\n",
-     "Here shows an streaming multi-turn chat example using official `transformers` API with BigDL-LLM optimized Llama 2 (7B) model. First we need to define the conversation format for the model to complete:"
-    ]
-   },
-   {
-    "cell_type": "code",
-    "execution_count": null,
-    "metadata": {},
-    "outputs": [],
-    "source": [
-     "# format conversation with chat history\n",
-     "chat_history = []\n",
-     "\n",
-     "HUMAN_ID = \"### HUMAN:\\n\\n\"\n",
-     "BOT_ID = \"### RESPONSE:\\n\\n\"\n",
-     "\n",
-     "def format_prompt(input_str, chat_history):\n",
-     "    prompt = \"\"\n",
-     "    for history_input, history_response in chat_history:\n",
-     "      prompt += f\"{HUMAN_ID}{history_input}\\n\\n{BOT_ID}{history_response}\\n\\n\"\n",
-     "    prompt += f\"{HUMAN_ID}{input_str}\\n\\n{BOT_ID}\"\n",
-     "    return prompt"
-    ]
-   },
-   {
-    "attachments": {},
-    "cell_type": "markdown",
-    "metadata": {},
-    "source": [
-     "Then we could define the function for streaming chat with the help of `transformers.TextIteratorStreamer`:"
-    ]
-   },
-   {
-    "cell_type": "code",
-    "execution_count": null,
-    "metadata": {},
-    "outputs": [],
-    "source": [
-     "from transformers import TextIteratorStreamer\n",
-     "from transformers.tools.agents import StopSequenceCriteria\n",
-     "from transformers.generation.stopping_criteria import StoppingCriteriaList\n",
-     "from threading import Thread\n",
-     "\n",
-     "def stream_chat(model, tokenizer, input_str, chat_history):\n",
-     "    prompt = format_prompt(input_str, chat_history)\n",
-     "    input_ids = tokenizer([prompt], return_tensors='pt')\n",
-     "\n",
-     "    streamer = TextIteratorStreamer(tokenizer,\n",
-     "                                    skip_prompt=True, # skip prompt in the generated tokens\n",
-     "                                    skip_special_tokens=True)\n",
-     "    \n",
-     "    # make sure that the generated tokens stop at ###, i.e. aviod the model from self-questioning\n",
-     "    stop_word = \"###\"\n",
-     "    stopping_criteria = StoppingCriteriaList([StopSequenceCriteria(stop_word, tokenizer)])\n",
-     "\n",
-     "    generate_kwargs = dict(\n",
-     "        input_ids,\n",
-     "        streamer=streamer,\n",
-     "        max_new_tokens=128,\n",
-     "        stopping_criteria=stopping_criteria\n",
-     "    )\n",
-     "    \n",
-     "    # To ensure non-blocking access to the generated text, generation process should be ran in a separate thread.\n",
-     "    thread = Thread(target=model.generate, kwargs=generate_kwargs)\n",
-     "    thread.start()\n",
-     "\n",
-     "    output_str = []\n",
-     "    print(\"Response: \", end=\"\")\n",
-     "    for stream_output in streamer:\n",
-     "        output_str.append(stream_output)\n",
-     "        print(stream_output.replace(stop_word, \"\"), end=\"\")\n",
-     "\n",
-     "    chat_history.append((input, ''.join(output_str).replace(stop_word, \"\")))\n"
-    ]
-   },
-   {
-    "attachments": {},
-    "cell_type": "markdown",
-    "metadata": {},
-    "source": [
-     "> **Note**\n",
-     ">\n",
-     "> The [`transformers` streamer classes](https://huggingface.co/docs/transformers/main/generation_strategies#streaming) is currently being developed and is subject to future changes."
-    ]
-   },
-   {
-    "attachments": {},
-    "cell_type": "markdown",
-    "metadata": {},
-    "source": [
-     "we can then facilitate interactive, multi-turn streaming chat between humans and the bot by allowing for continuous user input:"
-    ]
-   },
-   {
-    "cell_type": "code",
-    "execution_count": 6,
-    "metadata": {},
-    "outputs": [
-     {
-      "name": "stdin",
-      "output_type": "stream",
-      "text": [
-       "Input:  What is AI in short?\n"
-      ]
-     },
-     {
-      "name": "stdout",
-      "output_type": "stream",
-      "text": [
-       "Response: Artificial intelligence (AI) is the broader field of research and development aimed at creating machines that can perform tasks that typically require human intelligence, such as learning, problem-solving, decision-making, and perception. AI is a subset of machine learning, which focuses specifically on developing algorithms and statistical models that enable machines to learn from data, without being explicitly programmed.\n",
-       "\n"
-      ]
-     },
-     {
-      "name": "stdin",
-      "output_type": "stream",
-      "text": [
-       "Input:  Is it dangerous?\n"
-      ]
-     },
-     {
-      "name": "stdout",
-      "output_type": "stream",
-      "text": [
-       "Response: The potential dangers of AI are a topic of ongoing debate and research. Some of the concerns that have been raised include:\n",
-       "\n",
-       "1. Job displacement: AI could automate many jobs currently performed by humans, leading to job displacement and economic disruption.\n",
-       "2. Bias and discrimination: AI systems can perpetuate and amplify existing biases and discrimination if they are trained on biased data or designed with a particular worldview.\n",
-       "3. Privacy and security risks: AI systems can potentially collect and process large amounts of personal data, which could be used for"
-      ]
-     },
-     {
-      "name": "stdin",
-      "output_type": "stream",
-      "text": [
-       "Input:  stop\n"
-      ]
-     },
-     {
-      "name": "stdout",
-      "output_type": "stream",
-      "text": [
-       "Chat with Llama 2 (7B) stopped.\n"
-      ]
-     }
-    ],
-    "source": [
-     "while True:\n",
-     "  with torch.inference_mode():\n",
-     "    user_input = input(\"Input: \")\n",
-     "    if user_input == \"stop\": # let's stop the conversation when user input \"stop\"\n",
-     "      print(\"Chat with Llama 2 (7B) stopped.\")\n",
-     "      break\n",
-     "    stream_chat(model=model_in_4bit,\n",
-     "                tokenizer=tokenizer,\n",
-     "                input_str=user_input,\n",
-     "                chat_history=chat_history)"
-    ]
-   },
-   {
-    "attachments": {},
-    "cell_type": "markdown",
-    "metadata": {},
-    "source": [
-     "## 4.1.3 Save & Load INT4 Model\n",
-     "\n",
-     "When loading a model with `load_in_4bit=True`, BigDL-LLM implicitly converts linear layers in the model into INT4 format. In theory, a model with *X* B(illion) parameters saved in 16 or 32 bit will requires approximately 2*X* or 4*X* GB of memory for loading. Thus, for extremely large models like the 40B Falcon, 70B Llama 2, 176B Bloom etc., loading them with implicit INT4 quantization of BigDL-LLM can be both resource-intensive and time-consuming, and may even become impossible on memory-limited machines.\n",
-     "\n",
-     "To address this issue, BigDL-LLM provides support for saving *transformers* models in BigDL-LLM INT4 format. Once the model is optimized and saved in this format, it can be loaded directly for subsequent inference, eliminating the need for repeated quantization. The saving and loading process can be completed on different machines.\n",
-     "\n",
-     "### 4.1.3.1 Save INT4 Model\n",
-     "\n",
-     "Let's continue with the example in section [3.1.1](#311-load-model-in-int4-and-conduct-inference) for model Llama 2 (7B). After we loading the model in 4 bit, we could use the `save_low_bit` function to save the optimized model:"
-    ]
-   },
-   {
-    "cell_type": "code",
-    "execution_count": null,
-    "metadata": {},
-    "outputs": [],
-    "source": [
-     "save_directory='./llama-2-7b-bigdl-llm-4-bit'\n",
-     "\n",
-     "model_in_4bit.save_low_bit(save_directory)"
-    ]
-   },
-   {
-    "attachments": {},
-    "cell_type": "markdown",
-    "metadata": {},
-    "source": [
-     "We recommend saving the tokenizer in the same directory as the optimized model to simplify the subsequent loading process:"
-    ]
-   },
-   {
-    "cell_type": "code",
-    "execution_count": null,
-    "metadata": {},
-    "outputs": [],
-    "source": [
-     "tokenizer.save_pretrained(save_directory)"
-    ]
-   },
-   {
-    "attachments": {},
-    "cell_type": "markdown",
-    "metadata": {},
-    "source": [
-     "### 4.1.3.2 Load INT4 Model\n",
-     "\n",
-     "We could load the optimized INT4 model through `load_low_bit` function, and load tokenizer from the same saved directory:"
-    ]
-   },
-   {
-    "cell_type": "code",
-    "execution_count": null,
-    "metadata": {},
-    "outputs": [],
-    "source": [
-     "# note that the AutoModelForCausalLM here is imported from bigdl.llm.transformers\n",
-     "model_loaded = AutoModelForCausalLM.load_low_bit(save_directory)\n",
-     "\n",
-     "tokenizer_loaded = LlamaTokenizer.from_pretrained(save_directory)"
-    ]
-   },
-   {
-    "attachments": {},
-    "cell_type": "markdown",
-    "metadata": {},
-    "source": [
-     "Inference can then be done same as using the Hugging Face *transformers* API:"
-    ]
-   },
-   {
-    "cell_type": "code",
-    "execution_count": 11,
-    "metadata": {},
-    "outputs": [
-     {
-      "name": "stdout",
-      "output_type": "stream",
-      "text": [
-       "-------------------- Output --------------------\n",
-       "### HUMAN:\n",
-       "\n",
-       "What is AI?\n",
-       "\n",
-       "### RESPONSE:\n",
-       "\n",
-       "AI is a branch of computer science focused on creating intelligent machines that can perform tasks that typically require human intelligence, such as visual perception, speech recognition\n"
-      ]
-     }
-    ],
-    "source": [
-     "from transformers import TextGenerationPipeline\n",
-     "\n",
-     "pipeline = TextGenerationPipeline(model=model_loaded, tokenizer=tokenizer_loaded, max_new_tokens=32)\n",
-     "output_str = pipeline(prompt)[0][\"generated_text\"]\n",
-     "print('-'*20, 'Output', '-'*20)\n",
-     "print(output_str)"
-    ]
-   },
-   {
-    "attachments": {},
-    "cell_type": "markdown",
-    "metadata": {},
-    "source": [
-     "## 4.1.4 Use INT8 and other Low Precision Format\n",
-     "\n",
-     "In addition to INT4, BigDL-LLM also supports other low-precision techniques such as INT8 and INT5. \n",
-     "\n",
-     "### 4.1.4.1 Load Model in Low Precision\n",
-     "To load the model with BigDL-LLM low-precision optimizations, you could specify `load_in_low_bit` parameter accordingly in the `from_pretrained` function. Let's take INT8 as an example here:\n"
-    ]
-   },
-   {
-    "cell_type": "code",
-    "execution_count": null,
-    "metadata": {},
-    "outputs": [],
-    "source": [
-     "# note that the AutoModelForCausalLM here is imported from bigdl.llm.transformers\n",
-     "# model_in_8bit = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path=\"meta-llama/Llama-2-7b-chat-hf\",\n",
-     "#                                                      load_in_low_bit=\"sym_int8\")\n",
-     "model_in_8bit = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path=\"/disk5/yuwen/models/Llama-2-7b-chat-hf\",\n",
-     "                                                     load_in_low_bit=\"sym_int8\")"
-    ]
-   },
-   {
-    "attachments": {},
-    "cell_type": "markdown",
-    "metadata": {},
-    "source": [
-     "> **Note**\n",
-     ">\n",
-     "> Currently, `load_in_low_bit` supports options `'sym_int4'`, `'asym_int4'`, `'sym_int5'`, `'asym_int5'` or `'sym_int8'`, in which 'sym' and 'asym' differentiate between symmetric and asymmetric quantization.\n",
-     ">\n",
-     "> It is worth mentioning that `load_in_4bit=True` is equivalent to `load_in_low_bit='sym_int4'`.\n",
-     "\n",
-     "Saving and loading INT8 or other low-precision models supported by BigDL-LLM follows the same usage as described in section [3.1.2](#312-save--load-int4-model).\n",
-     "\n",
-     "### 4.1.4.2 Load Tokenizer and Conduct Inference\n",
-     "\n",
-     "The following process is the same as using the Hugging Face *transformers* API:"
-    ]
-   },
-   {
-    "cell_type": "code",
-    "execution_count": 13,
-    "metadata": {},
-    "outputs": [
-     {
-      "name": "stdout",
-      "output_type": "stream",
-      "text": [
-       "-------------------- Output --------------------\n",
-       "### HUMAN:\n",
-       "\n",
-       "What is AI?\n",
-       "\n",
-       "### RESPONSE:\n",
-       "\n",
-       "Artificial intelligence (AI) is the simulation of human intelligence in machines that are programmed to think and learn like humans. It involves the use of\n"
-      ]
-     }
-    ],
-    "source": [
-     "pipeline = TextGenerationPipeline(model=model_in_8bit, tokenizer=tokenizer, max_new_tokens=32)\n",
-     "output_str = pipeline(prompt)[0][\"generated_text\"]\n",
-     "print('-'*20, 'Output', '-'*20)\n",
-     "print(output_str)"
-    ]
-   },
-   {
-    "attachments": {},
-    "cell_type": "markdown",
-    "metadata": {},
-    "source": [
-     "## 4.1.5 What's Next？\n",
-     "\n",
-     "In the next tutorial, we will guide you through a speech recognition pipeline that incorporates BigDL-LLM INT4 optimizations.\n"
-    ]
-   }
-  ],
-  "metadata": {
-   "kernelspec": {
-    "display_name": "Python 3 (ipykernel)",
-    "language": "python",
-    "name": "python3"
-   },
-   "language_info": {
-    "codemirror_mode": {
-     "name": "ipython",
-     "version": 3
-    },
-    "file_extension": ".py",
-    "mimetype": "text/x-python",
-    "name": "python",
-    "nbconvert_exporter": "python",
-    "pygments_lexer": "ipython3",
-    "version": "3.9.17"
-   }
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Notebook 4.1: Run Transformer Models\n",
+    "\n",
+    "BigDL-LLM supports the optimization of any Hugging Face *transformers* model, allowing for efficient inference with significantly reduced latency. With the help of BigDL-LLM, PyTorch models (in FP16/BF16/FP32) from Hugging Face can be loaded with implicit quantization, so that heavy operations in Transformer can be speeded up through low precision (such as INT4/INT5/INT8, etc.).\n",
+    "\n",
+    "In this tutorial, we will dive into the main usage of BigDL-LLM Transformers-style API for low-precision optimizations.\n",
+    "\n",
+    "## 4.1.1 Install BigDL-LLM\n",
+    "\n",
+    "Follow instructions in [Chapter 2](../ch_2_Environment_Setup/) to setup your environment if you haven't done so. Then install `bigdl-llm`:"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 4
- }
- 
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install BigDL-LLM[all]"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4.1.2 Load Model in INT4 and Conduct Inference\n",
+    "\n",
+    "One common use case for BigDL-LLM is to load a Hugging Face *transformers* model in INT4 precision and conduct inference with optimizations. Compared to the Hugging Face *transformers* API, only minor code changes are required.\n",
+    "\n",
+    "For illustration purposes, let's take model [meta-llama/Llama-2-7b-chat-hf](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf) as an example.\n",
+    "\n",
+    "### 4.1.2.1 Download Llama 2 (7B)\n",
+    "\n",
+    "To download the [meta-llama/Llama-2-7b-chat-hf](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf) model from Hugging Face, you will need to obtain access granted by Meta. Please follow the instructions provided [here](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/tree/main) to request access to the model.\n",
+    "\n",
+    "After receiving the access, download the model with your Hugging Face token:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from huggingface_hub import snapshot_download\n",
+    "\n",
+    "model_path = snapshot_download(repo_id='/meta-llama/Llama-2-7b-chat-hf',\n",
+    "                               token='hf_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX') # change it to your own Hugging Face access token"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Note**\n",
+    ">\n",
+    "> The model will by default be downloaded to `HF_HOME='~/.cache/huggingface'`.\n",
+    "\n",
+    "\n",
+    "### 4.1.1.2 Load Model in INT4\n",
+    "\n",
+    "To load the model with BigDL-LLM INT4 optimizations, you could simply import `bigdl.llm.transformers.AutoModelForCausalLM` instead of `transformers.AutoModelForCausalLM`, and specify `load_in_4bit=True` in the `from_pretrained` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bigdl.llm.transformers import AutoModelForCausalLM\n",
+    "\n",
+    "# model_in_4bit = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path=\"meta-llama/Llama-2-7b-chat-hf\",\n",
+    "#                                                      load_in_4bit=True)\n",
+    "model_in_4bit = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path=\"/disk5/yuwen/models/Llama-2-7b-chat-hf\",\n",
+    "                                                     load_in_4bit=True)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Note**\n",
+    ">\n",
+    "> BigDL-LLM has supported `AutoModel`, `AutoModelForCausalLM`, `AutoModelForSpeechSeq2Seq` and `AutoModelForSeq2SeqLM`.\n",
+    "\n",
+    "### 4.1.2.3 Load Tokenizer and Conduct Inference\n",
+    "\n",
+    "You could then load the corresponding tokenizer of Llama 2 (7B) and conduct inference with BigDL-LLM INT4 optimizations, in the exactly same way with using Hugging Face *transformers* API. A human-bot conversation is constructed here for the model to complete:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Inference time: xxxx s\n",
+      "-------------------- Output --------------------\n",
+      "### HUMAN:\n",
+      "\n",
+      "What is AI?\n",
+      "\n",
+      "### RESPONSE:\n",
+      "\n",
+      "AI is a branch of computer science that focuses on creating intelligent machines that can perform tasks that typically require human intelligence, such as understanding natural language,\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load tokenizer of Llama 2 (7B)\n",
+    "from transformers import LlamaTokenizer\n",
+    "# tokenizer = LlamaTokenizer.from_pretrained(pretrained_model_name_or_path=\"meta-llama/Llama-2-7b-chat-hf\")\n",
+    "tokenizer = LlamaTokenizer.from_pretrained(pretrained_model_name_or_path=\"/disk5/yuwen/models/Llama-2-7b-chat-hf\")\n",
+    "\n",
+    "# Generate predicted tokens\n",
+    "import torch\n",
+    "import time\n",
+    "\n",
+    "prompt = \"\"\"### HUMAN:\n",
+    "\n",
+    "What is AI?\n",
+    "\n",
+    "### RESPONSE:\n",
+    "\"\"\"\n",
+    "\n",
+    "with torch.inference_mode():\n",
+    "    input_ids = tokenizer.encode(prompt, return_tensors=\"pt\")\n",
+    "    st = time.time()\n",
+    "    output = model_in_4bit.generate(input_ids,\n",
+    "                                    max_new_tokens=32)\n",
+    "    end = time.time()\n",
+    "    output_str = tokenizer.decode(output[0], skip_special_tokens=True)\n",
+    "    print(f'Inference time: {end-st} s')\n",
+    "    print('-'*20, 'Output', '-'*20)\n",
+    "    print(output_str)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.1.2.4 Conduct Streaming Multi-Turn Chat\n",
+    "\n",
+    "One common application of large language models is as chatbots. There is no magic involved in chatbot interactions. LLMs simply predict and generate texts based on formatted, incomplete conversations, such as the example prompt we previously showcased:\n",
+    "\n",
+    "```\n",
+    "### HUMAN:\n",
+    "\n",
+    "What is AI?\n",
+    "\n",
+    "### RESPONSE:\n",
+    "```\n",
+    "\n",
+    "In multi-turn chatting, the generated texts by LLMs are added into the existing conversation texts, as follows:\n",
+    "\n",
+    "```\n",
+    "### HUMAN:\n",
+    "\n",
+    "What is AI?\n",
+    "\n",
+    "### RESPONSE:\n",
+    "\n",
+    "AI is a term used to describe the development of computer systems that can perform tasks that typically require human intelligence, such as understanding natural language, recognizing images.\n",
+    "\n",
+    "### HUMAN:\n",
+    "\n",
+    "Is it dangerous\n",
+    "\n",
+    "### RESPONSE:\n",
+    "```\n",
+    "\n",
+    "Here shows a streaming multi-turn chat example using official `transformers` API with BigDL-LLM optimized Llama 2 (7B) model. First we need to define the conversation format for the model to complete:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# format conversation with chat history\n",
+    "chat_history = []\n",
+    "\n",
+    "HUMAN_ID = \"### HUMAN:\\n\\n\"\n",
+    "BOT_ID = \"### RESPONSE:\\n\\n\"\n",
+    "\n",
+    "def format_prompt(input_str, chat_history):\n",
+    "    prompt = \"\"\n",
+    "    for history_input, history_response in chat_history:\n",
+    "      prompt += f\"{HUMAN_ID}{history_input}\\n\\n{BOT_ID}{history_response}\\n\\n\"\n",
+    "    prompt += f\"{HUMAN_ID}{input_str}\\n\\n{BOT_ID}\"\n",
+    "    return prompt"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we could define the function for stream chat with the help of `transformers.TextIteratorStreamer`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import TextIteratorStreamer\n",
+    "from transformers.tools.agents import StopSequenceCriteria\n",
+    "from transformers.generation.stopping_criteria import StoppingCriteriaList\n",
+    "from threading import Thread\n",
+    "\n",
+    "def stream_chat(model, tokenizer, input_str, chat_history):\n",
+    "    prompt = format_prompt(input_str, chat_history)\n",
+    "    input_ids = tokenizer([prompt], return_tensors='pt')\n",
+    "\n",
+    "    streamer = TextIteratorStreamer(tokenizer,\n",
+    "                                    skip_prompt=True, # skip prompt in the generated tokens\n",
+    "                                    skip_special_tokens=True)\n",
+    "    \n",
+    "    # make sure that the generated tokens stop at ###, i.e. aviod the model from self-questioning\n",
+    "    stop_word = \"###\"\n",
+    "    stopping_criteria = StoppingCriteriaList([StopSequenceCriteria(stop_word, tokenizer)])\n",
+    "\n",
+    "    generate_kwargs = dict(\n",
+    "        input_ids,\n",
+    "        streamer=streamer,\n",
+    "        max_new_tokens=128,\n",
+    "        stopping_criteria=stopping_criteria\n",
+    "    )\n",
+    "    \n",
+    "    # To ensure non-blocking access to the generated text, generation process should be ran in a separate thread.\n",
+    "    thread = Thread(target=model.generate, kwargs=generate_kwargs)\n",
+    "    thread.start()\n",
+    "\n",
+    "    output_str = []\n",
+    "    print(\"Response: \", end=\"\")\n",
+    "    for stream_output in streamer:\n",
+    "        output_str.append(stream_output)\n",
+    "        print(stream_output.replace(stop_word, \"\"), end=\"\")\n",
+    "\n",
+    "    chat_history.append((input, ''.join(output_str).replace(stop_word, \"\")))\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Note**\n",
+    ">\n",
+    "> The [`transformers` streamer classes](https://huggingface.co/docs/transformers/main/generation_strategies#streaming) is currently being developed and is subject to future changes."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then facilitate interactive, multi-turn streaming chat between humans and the bot by allowing for continuous user input:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input:  What is AI in short?\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Response: Artificial intelligence (AI) is the broader field of research and development aimed at creating machines that can perform tasks that typically require human intelligence, such as learning, problem-solving, decision-making, and perception. AI is a subset of machine learning, which focuses specifically on developing algorithms and statistical models that enable machines to learn from data, without being explicitly programmed.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input:  Is it dangerous?\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Response: The potential dangers of AI are a topic of ongoing debate and research. Some of the concerns that have been raised include:\n",
+      "\n",
+      "1. Job displacement: AI could automate many jobs currently performed by humans, leading to job displacement and economic disruption.\n",
+      "2. Bias and discrimination: AI systems can perpetuate and amplify existing biases and discrimination if they are trained on biased data or designed with a particular worldview.\n",
+      "3. Privacy and security risks: AI systems can potentially collect and process large amounts of personal data, which could be used for"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input:  stop\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chat with Llama 2 (7B) stopped.\n"
+     ]
+    }
+   ],
+   "source": [
+    "while True:\n",
+    "  with torch.inference_mode():\n",
+    "    user_input = input(\"Input: \")\n",
+    "    if user_input == \"stop\": # let's stop the conversation when user input \"stop\"\n",
+    "      print(\"Chat with Llama 2 (7B) stopped.\")\n",
+    "      break\n",
+    "    stream_chat(model=model_in_4bit,\n",
+    "                tokenizer=tokenizer,\n",
+    "                input_str=user_input,\n",
+    "                chat_history=chat_history)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4.1.3 Save & Load INT4 Model\n",
+    "\n",
+    "When loading a model with `load_in_4bit=True`, BigDL-LLM implicitly converts linear layers in the model into INT4 format. In theory, a model with *X* B(illion) parameters saved in 16 or 32 bit will requires approximately 2*X* or 4*X* GB of memory for loading. Thus, for extremely large models like the 40B Falcon, 70B Llama 2, 176B Bloom etc., loading them with implicit INT4 quantization of BigDL-LLM can be both resource-intensive and time-consuming, and may even become impossible on memory-limited machines.\n",
+    "\n",
+    "To address this issue, BigDL-LLM provides support for saving *transformers* models in BigDL-LLM INT4 format. Once the model is optimized and saved in this format, it can be loaded directly for subsequent inference, eliminating the need for repeated quantization. The saving and loading process can be completed on different machines.\n",
+    "\n",
+    "### 4.1.3.1 Save INT4 Model\n",
+    "\n",
+    "Let's continue with the example in section [3.1.1](#311-load-model-in-int4-and-conduct-inference) for model Llama 2 (7B). After we loading the model in 4 bit, we could use the `save_low_bit` function to save the optimized model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_directory='./llama-2-7b-bigdl-llm-4-bit'\n",
+    "\n",
+    "model_in_4bit.save_low_bit(save_directory)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We recommend saving the tokenizer in the same directory as the optimized model to simplify the subsequent loading process:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tokenizer.save_pretrained(save_directory)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.1.3.2 Load INT4 Model\n",
+    "\n",
+    "We could load the optimized INT4 model through `load_low_bit` function, and load tokenizer from the same saved directory:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# note that the AutoModelForCausalLM here is imported from bigdl.llm.transformers\n",
+    "model_loaded = AutoModelForCausalLM.load_low_bit(save_directory)\n",
+    "\n",
+    "tokenizer_loaded = LlamaTokenizer.from_pretrained(save_directory)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Inference can then be done same as using the Hugging Face *transformers* API:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------- Output --------------------\n",
+      "### HUMAN:\n",
+      "\n",
+      "What is AI?\n",
+      "\n",
+      "### RESPONSE:\n",
+      "\n",
+      "AI is a branch of computer science focused on creating intelligent machines that can perform tasks that typically require human intelligence, such as visual perception, speech recognition\n"
+     ]
+    }
+   ],
+   "source": [
+    "from transformers import TextGenerationPipeline\n",
+    "\n",
+    "pipeline = TextGenerationPipeline(model=model_loaded, tokenizer=tokenizer_loaded, max_new_tokens=32)\n",
+    "output_str = pipeline(prompt)[0][\"generated_text\"]\n",
+    "print('-'*20, 'Output', '-'*20)\n",
+    "print(output_str)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4.1.4 Use INT8 and other Low Precision Format\n",
+    "\n",
+    "In addition to INT4, BigDL-LLM also supports other low-precision techniques such as INT8 and INT5. \n",
+    "\n",
+    "### 4.1.4.1 Load Model in Low Precision\n",
+    "To load the model with BigDL-LLM low-precision optimizations, you could specify `load_in_low_bit` parameter accordingly in the `from_pretrained` function. Let's take INT8 as an example here:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# note that the AutoModelForCausalLM here is imported from bigdl.llm.transformers\n",
+    "# model_in_8bit = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path=\"meta-llama/Llama-2-7b-chat-hf\",\n",
+    "#                                                      load_in_low_bit=\"sym_int8\")\n",
+    "model_in_8bit = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path=\"/disk5/yuwen/models/Llama-2-7b-chat-hf\",\n",
+    "                                                     load_in_low_bit=\"sym_int8\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Note**\n",
+    ">\n",
+    "> Currently, `load_in_low_bit` supports options `'sym_int4'`, `'asym_int4'`, `'sym_int5'`, `'asym_int5'` or `'sym_int8'`, in which 'sym' and 'asym' differentiate between symmetric and asymmetric quantization.\n",
+    ">\n",
+    "> It is worth mentioning that `load_in_4bit=True` is equivalent to `load_in_low_bit='sym_int4'`.\n",
+    "\n",
+    "Saving and loading INT8 or other low-precision models supported by BigDL-LLM follows the same usage as described in section [3.1.2](#312-save--load-int4-model).\n",
+    "\n",
+    "### 4.1.4.2 Load Tokenizer and Conduct Inference\n",
+    "\n",
+    "The following process is the same as using the Hugging Face *transformers* API:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------- Output --------------------\n",
+      "### HUMAN:\n",
+      "\n",
+      "What is AI?\n",
+      "\n",
+      "### RESPONSE:\n",
+      "\n",
+      "Artificial intelligence (AI) is the simulation of human intelligence in machines that are programmed to think and learn like humans. It involves the use of\n"
+     ]
+    }
+   ],
+   "source": [
+    "pipeline = TextGenerationPipeline(model=model_in_8bit, tokenizer=tokenizer, max_new_tokens=32)\n",
+    "output_str = pipeline(prompt)[0][\"generated_text\"]\n",
+    "print('-'*20, 'Output', '-'*20)\n",
+    "print(output_str)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4.1.5 What's Next？\n",
+    "\n",
+    "In the next tutorial, we will guide you through a speech recognition pipeline that incorporates BigDL-LLM INT4 optimizations.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Issue: https://github.com/analytics-zoo/nano/issues/476
Preview: https://github.com/Oscilloscope98/bigdl-llm-tutorial/blob/run-transformers-models/ch_4_Run_Models/4_1_Run_Transformer_Models.ipynb

Notebook 3.1: Run Transformer Models

- [x] Notebook 3.1: Run Transformer Models
    - [x] Intro (no need to add a seperate section)
        - BigDL-LLM can support any HF transformer models
         - load fp16/fp32 pytorch models from huggingface and implicitly quantize
         - speedup the heavy operations in transformers using low precision (INT4/INT5/INT8, etc.)
    - [x] Using INT4 
	          - load (w/conversion) + inference  (follow [llama2](https://github.com/intel-analytics/BigDL/tree/main/python/llm/example/transformers/transformers_int4/llama2))
    - [x] Save / Load
	          - save/load to quantize only once and inference many times (follow [transformers\_low\_bit](https://github.com/intel-analytics/BigDL/tree/main/python/llm/example/transformers/transformers_low_bit) )
    - [x] INT8 and more (follow [transformers\_low\_bit](https://github.com/intel-analytics/BigDL/tree/main/python/llm/example/transformers/transformers_low_bit) ) 
    - [x] What's Next
- [x] Add related notebook output