### PR TITLE
Update Chinese audio file name in 5_2_Speech_Recognition

### DIFF
--- a/ch_5_AppDev_Intermediate/5_2_Speech_Recognition.ipynb
+++ b/ch_5_AppDev_Intermediate/5_2_Speech_Recognition.ipynb
@@ -203,7 +203,7 @@
     "\n",
     "## 5.2.6 Transcribe Chinese Audio and Translate to English\n",
     "\n",
-    "Then let's move to the Chinese audio `audio_ch.wav`. Whisper can transcribe multilingual audio, and translate them into English. The only difference here is to define specific context token through `forced_decoder_ids`:"
+    "Then let's move to the Chinese audio `audio_zh.wav`. Whisper can transcribe multilingual audio, and translate them into English. The only difference here is to define specific context token through `forced_decoder_ids`:"
    ]
   },
   {
@@ -224,7 +224,7 @@
    ],
    "source": [
     "# extract sequence data\n",
-    "data_zh, sample_rate_zh = librosa.load(\"audio_ch.wav\", sr=16000)\n",
+    "data_zh, sample_rate_zh = librosa.load(\"audio_zh.wav\", sr=16000)\n",
     "\n",
     "# define Chinese transcribe task\n",
     "forced_decoder_ids = processor.get_decoder_prompt_ids(language=\"chinese\", task=\"transcribe\")\n",


### PR DESCRIPTION
**Updated section:**
5.2.6

**Updated content:**
Change Chinese audio file name `audio_ch.wav` in 5.2.6 to `audio_zh.wav` to keep it consistent with the file name defined in 5.2.2.